### PR TITLE
Add project key to cache key

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/bitbucket/client/BitbucketCloudApiClient.java
@@ -784,11 +784,17 @@ public class BitbucketCloudApiClient implements BitbucketApi {
                 .set("pagelen", MAX_PAGE_LENGTH);
         if (StringUtils.isNotBlank(projectKey)) {
             template.set("q", "project.key=" + "\"" + projectKey + "\""); // q=project.key="<projectKey>"
+            cacheKey.append("::").append(projectKey);
+        } else {
+            cacheKey.append("::<undefined>");
         }
         if (role != null &&  authenticator != null) {
             template.set("role", role.getId());
             cacheKey.append("::").append(role.getId());
+        } else {
+            cacheKey.append("::<undefined>");
         }
+
         Callable<List<BitbucketCloudRepository>> request = () -> {
             List<BitbucketCloudRepository> repositories = new ArrayList<>();
             Integer pageNumber = 1;


### PR DESCRIPTION
If a requests is sent with a project key, and the key is not part of the cache key, following requests for other projects will result in the cached repositories for the first project, leading to wrong results

<!-- Please describe your pull request here. -->

<!--
To mark your pull request as work in progress please create it as a draft pull request
-->

### Your checklist for this pull request

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or in [Jenkins JIRA](https://issues.jenkins-ci.org)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Did you provide a test-case? That demonstrates feature works or fixes the issue.

<!--
Put an `x` into the [ ] to show you have filled the information below
Describe your pull request below
-->
